### PR TITLE
Revert "Looked up how `goconvey` does that, turns out to be pretty easy."

### DIFF
--- a/result.go
+++ b/result.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -55,8 +54,7 @@ var wsd, resultPath string
 
 //Test execute the test and creates an Allure result used by Allure reports
 func Test(t *testing.T, description string, testFunc func()) {
-	_, file, _, _ := runtime.Caller(0)
-	wsd := filepath.Dir(file)
+	wsd = os.Getenv("ALLURE_RESULTS_PATH")
 	resultPath = fmt.Sprintf("%s/allure-results", wsd)
 
 	var r Result


### PR DESCRIPTION
Reverts dailymotion/allure-go#4
The runtime.caller(0) returns the root level of the package in the vendor folder, not the root level of the project.
runtime.caller(1) would return the path of the test file.