### PR TITLE
adding custom labels to allure results

### DIFF
--- a/example/example_parameters_test.go
+++ b/example/example_parameters_test.go
@@ -94,6 +94,7 @@ func TestAllureWithLabels(t *testing.T) {
 		allure.Feature("feature2"),
 		allure.Tag("tag1"),
 		allure.Tags("tag2", "tag3"),
+		allure.Label("customLabel1", "customLabel2"),
 		allure.Action(func() {}))
 }
 

--- a/options.go
+++ b/options.go
@@ -115,3 +115,9 @@ func ParentSuite(parentSuite string) Option {
 		r.addLabel("parentSuite", parentSuite)
 	}
 }
+
+func Label(labelName string, labelValue string) Option {
+	return func(r hasOptions) {
+		r.addLabel(labelName, labelValue)
+	}
+}


### PR DESCRIPTION
We are using custom post processors of allure report json to integrate it with third parties.
It would be nice to have a possibility to add custom labels.
