### PR TITLE
Added links and layer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ vendor/
 # Intellij IDEA folder
 .idea/
 /maven_reference_project/
+
+# Mac OS
+.DS_Store

--- a/example/example_link_test.go
+++ b/example/example_link_test.go
@@ -1,0 +1,14 @@
+package example
+
+import (
+	"github.com/dailymotion/allure-go"
+	"testing"
+)
+
+func TestAllureWithLinks(t *testing.T) {
+	allure.Test(t, allure.Description("Test with links"),
+		allure.Link("https://github.com/", "GitHub Link"),
+		allure.Issue("https://github.com/", "GitHub Issue"),
+		allure.TestCase("https://github.com/", "GitHub TestCase"),
+		allure.Action(func() {}))
+}

--- a/example/example_parameters_test.go
+++ b/example/example_parameters_test.go
@@ -92,6 +92,7 @@ func TestAllureWithLabels(t *testing.T) {
 		allure.Story("story2"),
 		allure.Feature("feature1"),
 		allure.Feature("feature2"),
+		allure.Layer("integration-tests"),
 		allure.Tag("tag1"),
 		allure.Tags("tag2", "tag3"),
 		allure.Label("customLabel1", "customLabel1Value"),

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,6 +1,7 @@
 package allure
 
 type hasOptions interface {
+	addLink(url, name string, linkType LinkType)
 	addLabel(key string, value string)
 	addDescription(description string)
 	addParameter(name string, value interface{})

--- a/link.go
+++ b/link.go
@@ -1,0 +1,15 @@
+package allure
+
+type LinkType string
+
+const (
+	IssueType    LinkType = "issue"
+	AnyLinkType  LinkType = "link"
+	TestCaseType LinkType = "test_case"
+)
+
+type link struct {
+	Url  string   `json:"url,omitempty"`
+	Name string   `json:"name,omitempty"`
+	Type LinkType `json:"type,omitempty"`
+}

--- a/options.go
+++ b/options.go
@@ -98,6 +98,30 @@ func Name(name string) Option {
 	}
 }
 
+func Layer(layer string) Option {
+	return func(r hasOptions) {
+		r.addLabel("layer", layer)
+	}
+}
+
+func Link(url, name string) Option {
+	return func(r hasOptions) {
+		r.addLink(url, name, AnyLinkType)
+	}
+}
+
+func Issue(url, name string) Option {
+	return func(r hasOptions) {
+		r.addLink(url, name, IssueType)
+	}
+}
+
+func TestCase(url, name string) Option {
+	return func(r hasOptions) {
+		r.addLink(url, name, TestCaseType)
+	}
+}
+
 func Suite(suite string) Option {
 	return func(r hasOptions) {
 		r.addLabel("suite", suite)

--- a/result.go
+++ b/result.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-//result is the top level report object for a test
+// result is the top level report object for a test
 type result struct {
 	UUID          string         `json:"uuid,omitempty"`
 	TestCaseID    string         `json:"testCaseId,omitempty"`
@@ -30,6 +30,7 @@ type result struct {
 	Children      []string       `json:"children,omitempty"`
 	FullName      string         `json:"fullName,omitempty"`
 	Labels        []label        `json:"labels,omitempty"`
+	Links         []link         `json:"links,omitempty"`
 	Test          func()         `json:"-"`
 }
 
@@ -133,6 +134,14 @@ func (r *result) setDefaultLabels(t *testing.T) {
 
 	//	Thread      string
 	//	Framework   string
+}
+
+func (r *result) addLink(url, name string, linkType LinkType) {
+	r.Links = append(r.Links, link{
+		Url:  url,
+		Name: name,
+		Type: linkType,
+	})
 }
 
 func (r *result) addLabel(name string, value string) {

--- a/step.go
+++ b/step.go
@@ -30,6 +30,10 @@ func (s *stepObject) addReason(reason string) {
 	s.StatusDetails.Message = reason
 }
 
+func (s *stepObject) addLink(url, name string, linkType LinkType) {
+	// Step doesn't have links
+}
+
 func (s *stepObject) addLabel(key string, value string) {
 	// Step doesn't have labels
 }

--- a/test_phase_container.go
+++ b/test_phase_container.go
@@ -26,7 +26,7 @@ type container struct {
 	Stop        int64           `json:"stop"`
 }
 
-//subContainer defines a step
+// subContainer defines a step
 type subContainer struct {
 	Name          string         `json:"name,omitempty"`
 	Status        string         `json:"status,omitempty"`
@@ -39,6 +39,10 @@ type subContainer struct {
 	Attachments   []attachment   `json:"attachments,omitempty"`
 	Parameters    []parameter    `json:"parameters,omitempty"`
 	Action        func()         `json:"-"`
+}
+
+func (s *subContainer) addLink(url, name string, linkType LinkType) {
+	panic("implement me")
 }
 
 func (sc *subContainer) addLabel(key string, value string) {


### PR DESCRIPTION
- Added support for test layers in Allure TestOps according to the [docs](https://docs.qameta.io/allure-testops/faq/labels/#testlayer)
- Implemented support for creating links, including `Link`, `Issue`, and `TestCase` types

Example of layers usage:
```go
func TestLayers(t *testing.T) {
	allure.Test(t, allure.Description("Test layers"),
		allure.Layer("integration-tests"),
		allure.Action(func() {}))
}
```

Example of links usage:
```go
func TestLinks(t *testing.T) {
	allure.Test(t, allure.Description("Test links"),
		allure.Link("https://github.com/", "GitHub Link"),
		allure.Issue("https://github.com/", "GitHub Issue"),
		allure.TestCase("https://github.com/", "GitHub TestCase"),
		allure.Action(func() {}))
}
```

In Allure TestOps, it will be displayed as follows:

<img width="588" alt="Снимок экрана 2023-08-12 в 09 40 01" src="https://github.com/dailymotion/allure-go/assets/63447343/a2bef91f-af16-4257-94b8-421561474742">
