### PR TITLE
Added the ability to add multiple labels in a single line of code

### DIFF
--- a/example/example_parameters_test.go
+++ b/example/example_parameters_test.go
@@ -96,6 +96,7 @@ func TestAllureWithLabels(t *testing.T) {
 		allure.Tag("tag1"),
 		allure.Tags("tag2", "tag3"),
 		allure.Label("customLabel1", "customLabel1Value"),
+		allure.Labels("customLabel2", "customLabel2Value1", "customLabel2Value2"),
 		allure.Action(func() {}))
 }
 

--- a/options.go
+++ b/options.go
@@ -145,3 +145,11 @@ func Label(labelName string, labelValue string) Option {
 		r.addLabel(labelName, labelValue)
 	}
 }
+
+func Labels(labelName string, labelValues ...string) Option {
+	return func(r hasOptions) {
+		for _, labelValue := range labelValues {
+			r.addLabel(labelName, labelValue)
+		}
+	}
+}


### PR DESCRIPTION
Added the ability to add multiple labels in a single line of code

Before:
```go
func TestLabel(t *testing.T) {
	allure.Test(t,
		allure.Name("Label Name"),
		allure.Label("jira", "LABEL-1111"),
		allure.Label("jira", "LABEL-1112"),
		allure.Label("jira", "LABEL-1113"),
		allure.Label("jira", "LABEL-1114"),
		allure.Label("jira", "LABEL-1115"),
		allure.Action(func() {}),
	)
}
```

After:
```go
func TestLabels(t *testing.T) {
	allure.Test(t,
		allure.Name("Labels Name"),
		allure.Labels("jira", "LABEL-1111", "LABEL-1112", "LABEL-1113", "LABEL-1114", "LABEL-1115"),
		allure.Action(func() {}),
	)
}
```

Additionally, it's useful for parameterized tests

```go
func TestLabels(t *testing.T) {
	tests := []TestCase{
		{
			Id:    "1",
			Name:  "Name1",
			Tasks: []string{"LABEL-1111", "LABEL-1112"},
		},
		{
			Id:    "2",
			Name:  "Name2",
			Tasks: []string{"LABEL-1113", "LABEL-1116", "LABEL-1119"},
		},
	}

	for _, test := range tests {
		allure.Test(t,
			allure.ID(test.Id),
			allure.Name(test.Name),
			allure.Labels("jira", test.Tasks...),
			allure.Action(func() {}),
		)
	}
}
```